### PR TITLE
Review and correct monthly benefit expirations

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -312,21 +312,21 @@ const availableCards = {
         benefits: [
             {
                 id: 'amex-gold-dining',
-                name: '$120 Dining Credit',
+                name: '$10 Dining Credit',
                 category: BENEFIT_CATEGORY.DINING,
-                frequency: BENEFIT_FREQUENCY.ANNUAL,
+                frequency: BENEFIT_FREQUENCY.MONTHLY,
                 type: BENEFIT_TYPE.CREDIT,
-                value: 120,
+                value: 10,
                 description: '$10/month at Grubhub, The Cheesecake Factory, and others',
                 used: false
             },
             {
                 id: 'amex-gold-uber',
-                name: '$120 Uber Cash',
+                name: '$10 Uber Cash',
                 category: BENEFIT_CATEGORY.RIDESHARE,
-                frequency: BENEFIT_FREQUENCY.ANNUAL,
+                frequency: BENEFIT_FREQUENCY.MONTHLY,
                 type: BENEFIT_TYPE.CREDIT,
-                value: 120,
+                value: 10,
                 description: '$10/month Uber credit',
                 used: false
             },


### PR DESCRIPTION
Fix Amex Gold card benefits to correctly reflect monthly frequency and value.

The $120 Dining Credit and $120 Uber Cash benefits were incorrectly configured as `ANNUAL` with a value of `120`. These are $10/month benefits, which caused them to display an incorrect expiration of 173 days. This PR corrects their frequency to `MONTHLY` and value to `10`, ensuring they expire within the current month as expected.