### PR TITLE
Add usage history audit log and contextual feedback form

### DIFF
--- a/Agent.md
+++ b/Agent.md
@@ -1,0 +1,92 @@
+# Agent Guide: CardBenefitTracker
+
+## Project Overview
+
+- Purpose: browser-only app to track credit-card benefits/credits/subscriptions/features.
+- Data model: cards contain `benefits[]` with usage flags (`used`, `subscribed`, `activated`).
+- Storage: local-only via `localStorage` key `creditCardBenefits`.
+- Stack: static HTML + React 18 UMD + Babel standalone + Tailwind CDN.
+- No Node build system, package manager, or backend.
+
+## Tech + Runtime Facts
+
+- Main page shell: `index.html`
+- Primary JS files loaded by `index.html`:
+  - `js/data.js`
+  - `js/utils.js`
+  - `js/components.js`
+  - `js/app.js`
+- Styles: `css/styles.css`
+- Optional local server: `serve.py` (Python, serves on port 8000 and opens browser)
+
+## Run / Verify
+
+- Quick server:
+  - `python3 -m http.server 8000`
+  - Open `http://localhost:8000`
+- Alternative:
+  - `python3 serve.py`
+- Test artifacts:
+  - `test-suite.html` (automated + manual checks)
+  - `test.html` (manual testing notes)
+
+## Architecture Notes
+
+- Global-script architecture (no ES modules/imports). Script load order in `index.html` matters.
+- `js/data.js` defines core enums and card catalog:
+  - `BENEFIT_FREQUENCY`
+  - `BENEFIT_TYPE`
+  - `BENEFIT_CATEGORY`
+  - `availableCards`
+- `js/utils.js` provides date/value helpers (`getCurrentBenefitAmount`, expiration helpers, currency formatting).
+- `js/components.js` contains UI components (`BenefitCard`, `CreditCardSection`, modals, settings).
+- `js/app.js` owns top-level React state and mounts app with `ReactDOM.createRoot(...).render(<App />)`.
+
+## Source Of Truth Rules
+
+- Treat `js/data.js` as the canonical card/benefit catalog.
+- Keep benefit objects consistent:
+  - `id`, `name`, `category`, `frequency`, `type`, `value`, `description`
+  - usage state fields by type:
+    - credit/one-time: `used`
+    - subscription: `subscribed`
+    - feature: `activated`
+- Preserve existing frequency/category/type enum values to avoid UI/filter breakage.
+
+## Known Gotchas (Important)
+
+- `index.html` currently contains a very large inline `<script type="text/babel">` that duplicates app/data logic already present in `js/*`.
+- `js/main.js` is another legacy duplicate of app/data logic and is not loaded by `index.html`.
+- `README.md` references `js/main.js` as an entry point, but runtime loading is through `index.html` + `js/data.js`/`js/utils.js`/`js/components.js`/`js/app.js`.
+- `test-suite.html` duplicates constants instead of importing from app files; keep parity in mind when changing enums.
+- `js/utils.js` includes benefit-name-specific logic (example: StubHub credit handling), so benefit renames can affect computed behavior.
+
+## Editing Guidelines For Agents
+
+- Make targeted edits; avoid broad rewrites unless explicitly requested.
+- Do not introduce Node-specific tooling unless asked (no existing npm workflow).
+- When adding/updating cards:
+  - edit `js/data.js`
+  - ensure IDs are unique and descriptive
+  - verify behavior in `Unused Only`, `Card View`, and `List View`
+- When changing display or action logic:
+  - update `js/components.js` and/or `js/app.js`
+  - confirm localStorage persistence still works
+- If touching duplicated areas (inline script / `js/main.js`), call out risk of divergence clearly in your change notes.
+
+## Asset + Research Notes
+
+- Card artwork assets live under `assets/cards/` (SVG and image helper scripts/URLs).
+- Card research prompt template lives at `prompts/research-card-benefits.md`.
+
+## Practical Workflow
+
+1. Start server (`python3 -m http.server 8000`).
+2. Make minimal change in canonical files (`js/data.js`, `js/utils.js`, `js/components.js`, `js/app.js`).
+3. Reload app and validate:
+   - add/remove card
+   - toggle credit/subscription
+   - view-mode switching
+   - settings reset actions
+4. Run through relevant parts of `test-suite.html`.
+5. Document any required sync with duplicate/legacy code paths.

--- a/css/styles.css
+++ b/css/styles.css
@@ -245,3 +245,196 @@ tr:hover .sticky-benefit-col:not(.sticky-benefit-col-used) {
     background: rgb(51 65 85);
     box-shadow: 2px 0 8px -2px rgba(0, 0, 0, 0.3);
 }
+
+/* Contextual feedback form blocks */
+.feedback-card {
+    border: 1px solid rgb(203 213 225 / 0.7);
+    background: rgb(255 255 255 / 0.88);
+    border-radius: 0.9rem;
+    padding: 1rem;
+    text-align: left;
+    box-shadow: 0 8px 25px -18px rgba(15, 23, 42, 0.65);
+}
+
+.dark .feedback-card {
+    border-color: rgb(71 85 105 / 0.8);
+    background: rgb(30 41 59 / 0.82);
+    box-shadow: 0 10px 24px -18px rgba(2, 6, 23, 0.95);
+}
+
+.feedback-card-compact {
+    padding: 0.85rem 1rem;
+}
+
+.feedback-card-header {
+    margin-bottom: 0.55rem;
+}
+
+.feedback-card-title {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.25rem;
+    font-weight: 600;
+    color: rgb(15 23 42);
+}
+
+.dark .feedback-card-title {
+    color: rgb(248 250 252);
+}
+
+.feedback-card-prompt {
+    margin-top: 0.2rem;
+    margin-bottom: 0;
+    font-size: 0.8rem;
+    color: rgb(71 85 105);
+}
+
+.dark .feedback-card-prompt {
+    color: rgb(148 163 184);
+}
+
+.feedback-cta-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+}
+
+.feedback-cta-button,
+.feedback-secondary-button,
+.feedback-primary-button {
+    border-radius: 0.6rem;
+    padding: 0.42rem 0.75rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    transition: all 0.2s ease;
+}
+
+.feedback-cta-button {
+    border: 1px solid rgb(148 163 184 / 0.65);
+    color: rgb(30 41 59);
+    background: rgb(248 250 252 / 0.85);
+}
+
+.feedback-cta-button:hover {
+    border-color: rgb(59 130 246 / 0.8);
+    color: rgb(30 64 175);
+}
+
+.dark .feedback-cta-button {
+    border-color: rgb(100 116 139 / 0.9);
+    color: rgb(226 232 240);
+    background: rgb(51 65 85 / 0.8);
+}
+
+.dark .feedback-cta-button:hover {
+    border-color: rgb(96 165 250 / 0.9);
+    color: rgb(191 219 254);
+}
+
+.feedback-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+}
+
+.feedback-form-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.feedback-label {
+    font-size: 0.74rem;
+    font-weight: 600;
+    color: rgb(51 65 85);
+}
+
+.dark .feedback-label {
+    color: rgb(203 213 225);
+}
+
+.feedback-input {
+    border: 1px solid rgb(148 163 184 / 0.55);
+    background: rgb(255 255 255 / 0.95);
+    border-radius: 0.55rem;
+    padding: 0.5rem 0.6rem;
+    font-size: 0.82rem;
+    color: rgb(15 23 42);
+}
+
+.dark .feedback-input {
+    border-color: rgb(100 116 139 / 0.85);
+    background: rgb(15 23 42 / 0.8);
+    color: rgb(241 245 249);
+}
+
+.feedback-textarea {
+    resize: vertical;
+    min-height: 4.5rem;
+}
+
+.feedback-form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.55rem;
+    margin-top: 0.1rem;
+}
+
+.feedback-secondary-button {
+    border: 1px solid rgb(148 163 184 / 0.7);
+    color: rgb(51 65 85);
+    background: rgb(248 250 252 / 0.9);
+}
+
+.feedback-primary-button {
+    border: 1px solid transparent;
+    color: white;
+    background: linear-gradient(135deg, rgb(37 99 235) 0%, rgb(79 70 229) 100%);
+}
+
+.feedback-primary-button:hover:not(:disabled) {
+    filter: brightness(1.05);
+}
+
+.feedback-primary-button:disabled {
+    opacity: 0.65;
+    cursor: wait;
+}
+
+.dark .feedback-secondary-button {
+    border-color: rgb(100 116 139 / 0.9);
+    color: rgb(226 232 240);
+    background: rgb(51 65 85 / 0.85);
+}
+
+.feedback-status {
+    margin: 0;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.feedback-status-success {
+    color: rgb(21 128 61);
+}
+
+.feedback-status-error {
+    color: rgb(220 38 38);
+}
+
+.dark .feedback-status-success {
+    color: rgb(74 222 128);
+}
+
+.dark .feedback-status-error {
+    color: rgb(248 113 113);
+}
+
+.feedback-helper-text {
+    margin: 0.6rem 0 0 0;
+    font-size: 0.71rem;
+    color: rgb(100 116 139);
+}
+
+.dark .feedback-helper-text {
+    color: rgb(148 163 184);
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -196,3 +196,52 @@ button:focus-visible {
 .dark ::-webkit-scrollbar-thumb:hover {
     background: rgba(71, 85, 105, 0.5);
 }
+
+/* Benefits table grid - 5 columns for sticky first column */
+.benefits-table-grid {
+    display: grid;
+    grid-template-columns: minmax(200px, 2fr) minmax(120px, 1fr) minmax(90px, 1fr) minmax(80px, 1fr) minmax(100px, 1fr);
+}
+
+/* Sticky Benefit column for horizontal scroll tables */
+.sticky-benefit-col {
+    position: sticky;
+    left: 0;
+    z-index: 10;
+    background: rgb(255 255 255);
+    box-shadow: 2px 0 8px -2px rgba(0, 0, 0, 0.08);
+}
+
+tr:hover .sticky-benefit-col:not(.sticky-benefit-col-used) {
+    background: rgb(248 250 252);
+}
+
+.sticky-benefit-col.sticky-benefit-col-used {
+    background: rgb(248 250 252);
+}
+
+.dark .sticky-benefit-col {
+    background: rgb(30 41 59);
+    box-shadow: 2px 0 8px -2px rgba(0, 0, 0, 0.3);
+}
+
+.dark tr:hover .sticky-benefit-col:not(.sticky-benefit-col-used) {
+    background: rgb(51 65 85);
+}
+
+.dark .sticky-benefit-col.sticky-benefit-col-used {
+    background: rgb(15 23 42);
+}
+
+.sticky-benefit-col-header {
+    position: sticky;
+    left: 0;
+    z-index: 20;
+    background: rgb(248 250 252);
+    box-shadow: 2px 0 8px -2px rgba(0, 0, 0, 0.08);
+}
+
+.dark .sticky-benefit-col-header {
+    background: rgb(51 65 85);
+    box-shadow: 2px 0 8px -2px rgba(0, 0, 0, 0.3);
+}

--- a/index.html
+++ b/index.html
@@ -1174,9 +1174,10 @@
             };
 
             if (viewMode === 'list') {
+                const stickyCellClass = `sticky left-0 z-10 py-3 px-6 min-w-[200px] ${isUsed ? 'bg-slate-50 dark:bg-slate-900' : 'bg-white dark:bg-slate-800'} shadow-[2px_0_8px_-2px_rgba(0,0,0,0.08)] dark:shadow-[2px_0_8px_-2px_rgba(0,0,0,0.3)]`;
                 return (
-                    <tr className={`border-b dark:border-slate-700 ${isUsed ? 'bg-slate-50 dark:bg-slate-900' : 'hover:bg-slate-50 dark:hover:bg-slate-900'}`}>
-                        <td className="py-3 px-6">
+                    <div className={`grid grid-cols-subgrid col-span-5 border-b border-slate-200 dark:border-slate-700 ${isUsed ? 'bg-slate-50 dark:bg-slate-900' : 'bg-white/50 dark:bg-slate-800/50 hover:bg-slate-50 dark:hover:bg-slate-900'}`}>
+                        <div className={stickyCellClass}>
                             <div className="flex items-center gap-3">
                                 <div className="w-8 h-8 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-white text-sm">
                                     {categoryIcons[benefit.category]}
@@ -1186,20 +1187,20 @@
                                     <div className="text-sm text-slate-600 dark:text-slate-400">{benefit.description}</div>
                                 </div>
                             </div>
-                        </td>
-                        <td className="py-3 px-6 text-sm font-medium text-slate-700 dark:text-slate-300">{cardName}</td>
-                        <td className="py-3 px-6">
+                        </div>
+                        <div className="py-3 px-6 text-sm font-medium text-slate-700 dark:text-slate-300">{cardName}</div>
+                        <div className="py-3 px-6">
                             <span className={`text-xs px-2 py-1 rounded-full ${expirationBg} ${expirationColor} font-medium`}>
                                 {daysLeft > 0 ? `${daysLeft} days` : 'Expired'}
                             </span>
-                        </td>
-                        <td className="py-3 px-6 text-sm font-medium text-slate-900 dark:text-slate-100">
+                        </div>
+                        <div className="py-3 px-6 text-sm font-medium text-slate-900 dark:text-slate-100">
                             {benefit.type === BENEFIT_TYPE.CREDIT && benefit.frequency !== BENEFIT_FREQUENCY.FOUR_YEAR 
                                 ? formatCurrency(currentAmount) 
                                 : formatCurrency(benefit.value)}
-                        </td>
-                        <td className="py-3 px-6 text-right">{renderButton()}</td>
-                    </tr>
+                        </div>
+                        <div className="py-3 px-6 text-right">{renderButton()}</div>
+                    </div>
                 );
             }
 
@@ -1432,13 +1433,18 @@
                                                     <p className="text-white/80 text-sm">Annual Fee: {formatCurrency(card.annualFee)}</p>
                                                 </div>
                                                 
-                                                <div className="p-4 flex justify-center bg-white dark:bg-gray-800">
-                                                    <img 
-                                                        src={cardImages[card.id] || `https://via.placeholder.com/300x200?text=${encodeURIComponent(card.name)}`} 
-                                                        alt={`${card.name} card`} 
-                                                        className="w-full h-48 object-cover rounded-lg shadow-md"
-                                                        loading="lazy"
-                                                    />
+                                                <div className="p-4 bg-white dark:bg-gray-800">
+                                                    <div
+                                                        className="relative w-full max-w-md mx-auto rounded-lg shadow-md overflow-hidden bg-gray-100 dark:bg-gray-700"
+                                                        style={{ aspectRatio: '1.586 / 1' }}
+                                                    >
+                                                        <img 
+                                                            src={cardImages[card.id] || `https://via.placeholder.com/300x200?text=${encodeURIComponent(card.name)}`} 
+                                                            alt={`${card.name} card`} 
+                                                            className="absolute inset-0 w-full h-full object-contain"
+                                                            loading="lazy"
+                                                        />
+                                                    </div>
                                                 </div>
                                                 
                                                 <div className="p-4">
@@ -2014,28 +2020,23 @@
                                                     <div className="w-3 h-3 bg-amber-500 rounded-full"></div>
                                                     Unused Benefits ({getUnusedBenefits().length})
                                                 </h3>
-                                                <div className="bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm rounded-2xl shadow-xl border border-slate-200/50 dark:border-slate-700/50 overflow-hidden">
-                                                    <table className="min-w-full">
-                                                        <thead className="bg-slate-50/80 dark:bg-slate-700/80">
-                                                            <tr>
-                                                                <th className="px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider">
-                                                                    Benefit
-                                                                </th>
-                                                                <th className="px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider">
-                                                                    Card
-                                                                </th>
-                                                                <th className="px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider">
-                                                                    Expires
-                                                                </th>
-                                                                <th className="px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider">
-                                                                    Value
-                                                                </th>
-                                                                <th className="px-6 py-4 text-right text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider">
-                                                                    Action
-                                                                </th>
-                                                            </tr>
-                                                        </thead>
-                                                        <tbody className="bg-white/50 dark:bg-slate-800/50 divide-y divide-slate-200/50 dark:divide-slate-700/50">
+                                                <div className="bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm rounded-2xl shadow-xl border border-slate-200/50 dark:border-slate-700/50 overflow-x-auto">
+                                                    <div className="grid benefits-table-grid min-w-[660px]">
+                                                        <div className="sticky left-0 z-20 px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider bg-slate-50 dark:bg-slate-700 shadow-[2px_0_8px_-2px_rgba(0,0,0,0.08)] dark:shadow-[2px_0_8px_-2px_rgba(0,0,0,0.3)]">
+                                                            Benefit
+                                                        </div>
+                                                        <div className="px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider bg-slate-50 dark:bg-slate-700">
+                                                            Card
+                                                        </div>
+                                                        <div className="px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider bg-slate-50 dark:bg-slate-700">
+                                                            Expires
+                                                        </div>
+                                                        <div className="px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider bg-slate-50 dark:bg-slate-700">
+                                                            Value
+                                                        </div>
+                                                        <div className="px-6 py-4 text-right text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider bg-slate-50 dark:bg-slate-700">
+                                                            Action
+                                                        </div>
                                                             {getUnusedBenefits().map((benefit) => (
                                                                 <BenefitCard
                                                                     key={`${benefit.cardId}-${benefit.id}`}
@@ -2049,8 +2050,7 @@
                                                                     viewMode="list"
                                                                 />
                                                             ))}
-                                                        </tbody>
-                                                    </table>
+                                                    </div>
                                                 </div>
                                             </div>
                                         )}
@@ -2062,28 +2062,23 @@
                                                     <div className="w-3 h-3 bg-green-500 rounded-full"></div>
                                                     Used Benefits ({getAllBenefits().filter(benefit => (benefit.used || benefit.subscribed || benefit.activated) && !recentlyUsed.has(benefit.id)).length})
                                                 </h3>
-                                                <div className="bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm rounded-2xl shadow-xl border border-slate-200/50 dark:border-slate-700/50 max-h-96 overflow-y-auto">
-                                                    <table className="min-w-full">
-                                                        <thead className="bg-slate-50/80 dark:bg-slate-700/80">
-                                                            <tr>
-                                                                <th className="px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider">
-                                                                    Benefit
-                                                                </th>
-                                                                <th className="px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider">
-                                                                    Card
-                                                                </th>
-                                                                <th className="px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider">
-                                                                    Expires
-                                                                </th>
-                                                                <th className="px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider">
-                                                                    Value
-                                                                </th>
-                                                                <th className="px-6 py-4 text-right text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider">
-                                                                    Action
-                                                                </th>
-                                                            </tr>
-                                                        </thead>
-                                                        <tbody className="bg-white/50 dark:bg-slate-800/50 divide-y divide-slate-200/50 dark:divide-slate-700/50">
+                                                <div className="bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm rounded-2xl shadow-xl border border-slate-200/50 dark:border-slate-700/50 max-h-96 overflow-auto">
+                                                    <div className="grid benefits-table-grid min-w-[660px]">
+                                                        <div className="sticky left-0 z-20 px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider bg-slate-50 dark:bg-slate-700 shadow-[2px_0_8px_-2px_rgba(0,0,0,0.08)] dark:shadow-[2px_0_8px_-2px_rgba(0,0,0,0.3)]">
+                                                            Benefit
+                                                        </div>
+                                                        <div className="px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider bg-slate-50 dark:bg-slate-700">
+                                                            Card
+                                                        </div>
+                                                        <div className="px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider bg-slate-50 dark:bg-slate-700">
+                                                            Expires
+                                                        </div>
+                                                        <div className="px-6 py-4 text-left text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider bg-slate-50 dark:bg-slate-700">
+                                                            Value
+                                                        </div>
+                                                        <div className="px-6 py-4 text-right text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider bg-slate-50 dark:bg-slate-700">
+                                                            Action
+                                                        </div>
                                                             {getAllBenefits().filter(benefit => (benefit.used || benefit.subscribed || benefit.activated) && !recentlyUsed.has(benefit.id)).map((benefit) => (
                                                                 <BenefitCard
                                                                     key={`${benefit.cardId}-${benefit.id}`}
@@ -2097,8 +2092,7 @@
                                                                     viewMode="list"
                                                                 />
                                                             ))}
-                                                        </tbody>
-                                                    </table>
+                                                    </div>
                                                 </div>
                                             </div>
                                         )}

--- a/index.html
+++ b/index.html
@@ -1001,42 +1001,86 @@
             };
         }
 
-        // Helper function to get current benefit amount based on date
-        const getCurrentBenefitAmount = (benefit, frequency) => {
-            const now = new Date();
-            const currentMonth = now.getMonth();
-            const currentYear = now.getFullYear();
-            
+        const HISTORY_STORAGE_KEY = 'benefitUsageHistory';
+        const HISTORY_MAX_ENTRIES = 3000;
+
+        const toDate = (dateLike = new Date()) => {
+            const parsed = dateLike instanceof Date ? new Date(dateLike) : new Date(dateLike);
+            return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+        };
+
+        const getSemiAnnualHalfFromBenefit = (benefit = {}) => {
+            const normalized = String(benefit.name || '').replace(/–/g, '-').toLowerCase();
+            if (normalized.includes('jan-jun') || normalized.includes('(h1)')) {
+                return 'H1';
+            }
+            if (normalized.includes('jul-dec') || normalized.includes('(h2)')) {
+                return 'H2';
+            }
+            return null;
+        };
+
+        const getPeriodKey = (frequency, referenceDate = new Date(), benefit = {}) => {
+            const date = toDate(referenceDate);
+            const year = date.getFullYear();
+            const month = date.getMonth() + 1;
+            const monthKey = String(month).padStart(2, '0');
+
             switch (frequency) {
-                case BENEFIT_FREQUENCY.SEMI_ANNUAL:
-                    // For semi-annual benefits, return half the value
-                    if (benefit.name.includes('Jan-Jun') && currentMonth >= 6) {
-                        return 0; // This period has passed
-                    }
-                    if (benefit.name.includes('Jul-Dec') && currentMonth < 6) {
-                        return 0; // This period hasn't started
-                    }
-                    return benefit.value;
+                case BENEFIT_FREQUENCY.MONTHLY:
+                    return `${year}-${monthKey}`;
+                case BENEFIT_FREQUENCY.SEMI_ANNUAL: {
+                    const forcedHalf = getSemiAnnualHalfFromBenefit(benefit);
+                    const derivedHalf = month <= 6 ? 'H1' : 'H2';
+                    return `${year}-${forcedHalf || derivedHalf}`;
+                }
                 case BENEFIT_FREQUENCY.ANNUAL:
-                    // For annual benefits that accumulate monthly
-                    if (benefit.name === '$300 StubHub/Viagogo Credit') {
-                        // $25 per month
-                        return Math.min(25 * (currentMonth + 1), 300);
+                case BENEFIT_FREQUENCY.ONE_TIME:
+                    return `${year}`;
+                case BENEFIT_FREQUENCY.FOUR_YEAR: {
+                    const periodStart = year - (year % 4);
+                    return `${periodStart}-${periodStart + 3}`;
+                }
+                default:
+                    return `${year}`;
+            }
+        };
+
+        const formatPeriodLabel = (periodKey, frequency) => {
+            if (!periodKey) return 'Unknown period';
+            if (frequency === BENEFIT_FREQUENCY.SEMI_ANNUAL) {
+                return periodKey.replace('-', ' ');
+            }
+            return periodKey;
+        };
+
+        // Helper function to get current benefit amount based on date
+        const getCurrentBenefitAmount = (benefit, frequency, referenceDate = new Date()) => {
+            const date = toDate(referenceDate);
+            const currentMonth = date.getMonth();
+
+            switch (frequency) {
+                case BENEFIT_FREQUENCY.SEMI_ANNUAL: {
+                    const benefitHalf = getSemiAnnualHalfFromBenefit(benefit);
+                    const currentHalf = currentMonth < 6 ? 'H1' : 'H2';
+                    if (benefitHalf && benefitHalf !== currentHalf) {
+                        return 0;
                     }
                     return benefit.value;
+                }
+                case BENEFIT_FREQUENCY.ANNUAL:
                 case BENEFIT_FREQUENCY.FOUR_YEAR:
-                    // TSA PreCheck is $120 every 4 years, not annual
-                    return benefit.value;
+                case BENEFIT_FREQUENCY.ONE_TIME:
                 default:
                     return benefit.value;
             }
         };
 
         // Helper functions
-        const getExpirationDate = (frequency) => {
-            const now = new Date();
-            const currentYear = now.getFullYear();
-            const currentMonth = now.getMonth();
+        const getExpirationDate = (frequency, referenceDate = new Date()) => {
+            const date = toDate(referenceDate);
+            const currentYear = date.getFullYear();
+            const currentMonth = date.getMonth();
             
             switch (frequency) {
                 case BENEFIT_FREQUENCY.MONTHLY:
@@ -1044,13 +1088,16 @@
                 case BENEFIT_FREQUENCY.SEMI_ANNUAL:
                     if (currentMonth < 6) {
                         return new Date(currentYear, 5, 30);
-                    } else {
-                        return new Date(currentYear, 11, 31);
                     }
-                case BENEFIT_FREQUENCY.ANNUAL:
                     return new Date(currentYear, 11, 31);
-                case BENEFIT_FREQUENCY.FOUR_YEAR:
-                    return new Date(currentYear + 4, 11, 31);
+                case BENEFIT_FREQUENCY.ANNUAL:
+                case BENEFIT_FREQUENCY.ONE_TIME:
+                    return new Date(currentYear, 11, 31);
+                case BENEFIT_FREQUENCY.FOUR_YEAR: {
+                    const periodKey = getPeriodKey(BENEFIT_FREQUENCY.FOUR_YEAR, date);
+                    const endYear = Number(periodKey.split('-')[1]);
+                    return new Date(endYear, 11, 31);
+                }
                 default:
                     return new Date(currentYear, 11, 31);
             }
@@ -1074,6 +1121,199 @@
         };
 
         const { useState, useEffect } = React;
+        // Formspree setup:
+        // 1) Create a form at https://formspree.io/ and copy your endpoint.
+        // 2) Replace REPLACE_ME below with your form ID.
+        // 3) Verify recipient email and submit one test message from the app.
+        const FEEDBACK_FORM_ENDPOINT = 'https://formspree.io/f/xvzdabnp';
+        const FEEDBACK_FALLBACK_EMAIL = 'shotadevelops@gmail.com';
+
+        function ContextualFeedbackForm({
+            contextType,
+            title = 'Share feedback',
+            prompt = 'Tell us what is missing or incorrect.',
+            compact = false,
+            quickActions = [],
+            defaultIssueType = 'other',
+            pageMeta = ''
+        }) {
+            const [isExpanded, setIsExpanded] = useState(false);
+            const [issueType, setIssueType] = useState(defaultIssueType);
+            const [message, setMessage] = useState('');
+            const [email, setEmail] = useState('');
+            const [status, setStatus] = useState({ type: '', text: '' });
+            const [isSubmitting, setIsSubmitting] = useState(false);
+
+            useEffect(() => {
+                setIssueType(defaultIssueType);
+            }, [defaultIssueType]);
+
+            const isEndpointConfigured = !FEEDBACK_FORM_ENDPOINT.includes('REPLACE_ME');
+
+            const openFeedback = (nextIssueType) => {
+                setIsExpanded(true);
+                if (nextIssueType) {
+                    setIssueType(nextIssueType);
+                }
+            };
+
+            const closeFeedback = () => {
+                setIsExpanded(false);
+                setStatus({ type: '', text: '' });
+            };
+
+            const handleSubmit = async (event) => {
+                event.preventDefault();
+
+                if (!message.trim()) {
+                    setStatus({ type: 'error', text: 'Please add a short description before submitting.' });
+                    return;
+                }
+
+                if (!isEndpointConfigured) {
+                    setStatus({
+                        type: 'error',
+                        text: `Feedback form is not connected yet. Replace FEEDBACK_FORM_ENDPOINT, or email ${FEEDBACK_FALLBACK_EMAIL}.`
+                    });
+                    return;
+                }
+
+                setIsSubmitting(true);
+                setStatus({ type: '', text: '' });
+
+                try {
+                    const response = await fetch(FEEDBACK_FORM_ENDPOINT, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            Accept: 'application/json'
+                        },
+                        body: JSON.stringify({
+                            issueType,
+                            message: message.trim(),
+                            email: email.trim() || undefined,
+                            contextType,
+                            pageMeta,
+                            submittedAt: new Date().toISOString(),
+                            url: window.location.href,
+                            userAgent: navigator.userAgent
+                        })
+                    });
+
+                    if (!response.ok) {
+                        throw new Error('Form submission failed');
+                    }
+
+                    setStatus({ type: 'success', text: 'Thanks for the report. It was sent successfully.' });
+                    setMessage('');
+                    setEmail('');
+                    setIssueType(defaultIssueType);
+                } catch (error) {
+                    setStatus({
+                        type: 'error',
+                        text: `We could not send your feedback right now. You can also email ${FEEDBACK_FALLBACK_EMAIL}.`
+                    });
+                } finally {
+                    setIsSubmitting(false);
+                }
+            };
+
+            return (
+                <div className={`feedback-card ${compact ? 'feedback-card-compact' : ''}`}>
+                    {!isExpanded ? (
+                        <div>
+                            <div className="feedback-card-header">
+                                <h4 className="feedback-card-title">{title}</h4>
+                                <p className="feedback-card-prompt">{prompt}</p>
+                            </div>
+                            <div className="feedback-cta-group">
+                                {quickActions.map((action) => (
+                                    <button
+                                        key={`${contextType}-${action.issueType}-${action.label}`}
+                                        onClick={() => openFeedback(action.issueType)}
+                                        className="feedback-cta-button"
+                                        type="button"
+                                    >
+                                        {action.label}
+                                    </button>
+                                ))}
+                                {quickActions.length === 0 && (
+                                    <button
+                                        onClick={() => openFeedback(defaultIssueType)}
+                                        className="feedback-cta-button"
+                                        type="button"
+                                    >
+                                        Open feedback form
+                                    </button>
+                                )}
+                            </div>
+                        </div>
+                    ) : (
+                        <form onSubmit={handleSubmit} className="feedback-form">
+                            <div className="feedback-form-row">
+                                <label htmlFor={`${contextType}-issueType`} className="feedback-label">Issue type</label>
+                                <select
+                                    id={`${contextType}-issueType`}
+                                    className="feedback-input"
+                                    value={issueType}
+                                    onChange={(e) => setIssueType(e.target.value)}
+                                >
+                                    <option value="missing_card">Missing card</option>
+                                    <option value="missing_benefit">Missing benefit</option>
+                                    <option value="incorrect_benefit">Incorrect benefit details</option>
+                                    <option value="feature_request">Feature request</option>
+                                    <option value="other">Other</option>
+                                </select>
+                            </div>
+
+                            <div className="feedback-form-row">
+                                <label htmlFor={`${contextType}-message`} className="feedback-label">What should be fixed?</label>
+                                <textarea
+                                    id={`${contextType}-message`}
+                                    className="feedback-input feedback-textarea"
+                                    value={message}
+                                    onChange={(e) => setMessage(e.target.value)}
+                                    placeholder="Example: Chase Freedom Flex is missing, or the dining credit amount is outdated."
+                                    rows="3"
+                                />
+                            </div>
+
+                            <div className="feedback-form-row">
+                                <label htmlFor={`${contextType}-email`} className="feedback-label">Email (optional)</label>
+                                <input
+                                    id={`${contextType}-email`}
+                                    type="email"
+                                    className="feedback-input"
+                                    value={email}
+                                    onChange={(e) => setEmail(e.target.value)}
+                                    placeholder="you@example.com"
+                                />
+                            </div>
+
+                            {status.text && (
+                                <p className={`feedback-status ${status.type === 'success' ? 'feedback-status-success' : 'feedback-status-error'}`}>
+                                    {status.text}
+                                </p>
+                            )}
+
+                            <div className="feedback-form-actions">
+                                <button type="button" className="feedback-secondary-button" onClick={closeFeedback}>
+                                    Cancel
+                                </button>
+                                <button type="submit" className="feedback-primary-button" disabled={isSubmitting}>
+                                    {isSubmitting ? 'Sending...' : 'Send feedback'}
+                                </button>
+                            </div>
+                        </form>
+                    )}
+                    {!isEndpointConfigured && (
+                        <p className="feedback-helper-text">
+                            Setup needed: replace `FEEDBACK_FORM_ENDPOINT` with your Formspree URL to enable submissions.
+                        </p>
+                    )}
+                </div>
+            );
+        }
 
 
         // Components
@@ -1479,6 +1719,19 @@
                                 </div>
                             ))
                         )}
+                        <div className="mt-8">
+                            <ContextualFeedbackForm
+                                contextType="add-cards-page"
+                                title="Don't see your credit card?"
+                                prompt="Report missing cards or request a new card to be added."
+                                defaultIssueType="missing_card"
+                                pageMeta="add-cards"
+                                quickActions={[
+                                    { label: "Don't see your card?", issueType: 'missing_card' },
+                                    { label: 'Request a new card', issueType: 'feature_request' }
+                                ]}
+                            />
+                        </div>
                     </main>
                 </div>
             );
@@ -1542,8 +1795,8 @@
                                 <div className="border border-red-200 dark:border-red-700 rounded-lg p-6 bg-red-50 dark:bg-red-900/20">
                                     <h3 className="text-lg font-semibold text-red-900 dark:text-red-300 mb-2">Reset All Data</h3>
                                     <p className="text-red-700 dark:text-red-400 mb-4">
-                                        <strong>Warning:</strong> This will permanently delete all your data including cards and benefit usage. 
-                                        This action cannot be undone.
+                                        <strong>Warning:</strong> This will permanently delete all your cards and active benefit usage state.
+                                        Usage history records are retained for audit purposes.
                                     </p>
                                     <button
                                         onClick={() => setShowResetAllModal(true)}
@@ -1571,8 +1824,8 @@
                             <div className="bg-white dark:bg-slate-800 rounded-lg p-6 max-w-md w-full">
                                 <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">Confirm Reset All Data</h3>
                                 <p className="text-slate-600 dark:text-slate-400 mb-6">
-                                    Are you sure you want to delete all your data? This will remove all cards and benefit usage history. 
-                                    This action cannot be undone.
+                                    Are you sure you want to delete all your cards and active usage state?
+                                    Usage history will be kept.
                                 </p>
                                 <div className="flex gap-3 justify-end">
                                     <button
@@ -1622,6 +1875,178 @@
             );
         }
 
+        function UsageHistoryPage({ historyEvents, cards, onBack }) {
+            const [selectedCardId, setSelectedCardId] = useState('all');
+            const [selectedAction, setSelectedAction] = useState('all');
+            const [groupMode, setGroupMode] = useState('date');
+            const [fromDate, setFromDate] = useState('');
+            const [toDateFilter, setToDateFilter] = useState('');
+
+            const cardOptions = React.useMemo(() => {
+                const options = [{ id: 'all', name: 'All Cards' }];
+                cards.forEach((card) => options.push({ id: card.id, name: card.name }));
+                return options;
+            }, [cards]);
+
+            const filteredEvents = React.useMemo(() => {
+                return historyEvents.filter((event) => {
+                    if (selectedCardId !== 'all' && event.cardId !== selectedCardId) return false;
+                    if (selectedAction !== 'all' && event.action !== selectedAction) return false;
+
+                    const eventDate = toDate(event.timestamp);
+                    if (fromDate) {
+                        const from = new Date(`${fromDate}T00:00:00`);
+                        if (eventDate < from) return false;
+                    }
+                    if (toDateFilter) {
+                        const to = new Date(`${toDateFilter}T23:59:59`);
+                        if (eventDate > to) return false;
+                    }
+                    return true;
+                });
+            }, [historyEvents, selectedCardId, selectedAction, fromDate, toDateFilter]);
+
+            const groupedEvents = React.useMemo(() => {
+                return filteredEvents.reduce((acc, event) => {
+                    const date = toDate(event.timestamp);
+                    const groupKey = groupMode === 'period'
+                        ? `${event.periodKey || 'unknown'}::${event.frequency || 'unknown'}`
+                        : date.toISOString().slice(0, 10);
+                    if (!acc[groupKey]) {
+                        acc[groupKey] = [];
+                    }
+                    acc[groupKey].push(event);
+                    return acc;
+                }, {});
+            }, [filteredEvents, groupMode]);
+
+            const sortedGroupKeys = React.useMemo(() => {
+                return Object.keys(groupedEvents).sort((a, b) => b.localeCompare(a));
+            }, [groupedEvents]);
+
+            const actionLabel = {
+                used: 'Marked used',
+                undo_used: 'Usage undone',
+                subscribed: 'Subscribed',
+                unsubscribed: 'Unsubscribed',
+                reset_usage: 'Reset benefit usage',
+                reset_all: 'Reset all data'
+            };
+
+            return (
+                <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900">
+                    <header className="bg-white/80 dark:bg-slate-800/80 backdrop-blur-lg border-b border-gray-200/50 dark:border-slate-700/50 sticky top-0 z-50">
+                        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+                            <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-4">
+                                    <button
+                                        onClick={onBack}
+                                        className="flex items-center gap-2 text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors"
+                                    >
+                                        <span className="text-xl">←</span>
+                                        <span>Back to Dashboard</span>
+                                    </button>
+                                    <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Usage History</h1>
+                                </div>
+                            </div>
+                        </div>
+                    </header>
+
+                    <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+                        <div className="bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm rounded-2xl shadow-xl border border-slate-200/50 dark:border-slate-700/50 p-4 md:p-6">
+                            <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+                                <select
+                                    value={selectedCardId}
+                                    onChange={(e) => setSelectedCardId(e.target.value)}
+                                    className="px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-900 text-sm"
+                                >
+                                    {cardOptions.map((card) => (
+                                        <option key={card.id} value={card.id}>{card.name}</option>
+                                    ))}
+                                </select>
+                                <select
+                                    value={selectedAction}
+                                    onChange={(e) => setSelectedAction(e.target.value)}
+                                    className="px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-900 text-sm"
+                                >
+                                    <option value="all">All Actions</option>
+                                    <option value="used">Marked used</option>
+                                    <option value="undo_used">Usage undone</option>
+                                    <option value="subscribed">Subscribed</option>
+                                    <option value="unsubscribed">Unsubscribed</option>
+                                    <option value="reset_usage">Reset usage</option>
+                                    <option value="reset_all">Reset all</option>
+                                </select>
+                                <input
+                                    type="date"
+                                    value={fromDate}
+                                    onChange={(e) => setFromDate(e.target.value)}
+                                    className="px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-900 text-sm"
+                                />
+                                <input
+                                    type="date"
+                                    value={toDateFilter}
+                                    onChange={(e) => setToDateFilter(e.target.value)}
+                                    className="px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-900 text-sm"
+                                />
+                                <select
+                                    value={groupMode}
+                                    onChange={(e) => setGroupMode(e.target.value)}
+                                    className="px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-900 text-sm"
+                                >
+                                    <option value="date">Group by Date</option>
+                                    <option value="period">Group by Period</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        {filteredEvents.length === 0 ? (
+                            <div className="bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm rounded-2xl shadow-xl border border-slate-200/50 dark:border-slate-700/50 p-12 text-center">
+                                <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-2">No usage events yet</h3>
+                                <p className="text-slate-600 dark:text-slate-400">
+                                    Mark a benefit as used or subscription as subscribed to start building history.
+                                </p>
+                            </div>
+                        ) : (
+                            <div className="space-y-5">
+                                {sortedGroupKeys.map((groupKey) => {
+                                    const events = groupedEvents[groupKey].slice().sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+                                    const [periodKey, frequency] = groupKey.split('::');
+                                    const title = groupMode === 'period'
+                                        ? formatPeriodLabel(periodKey, frequency)
+                                        : groupKey;
+                                    return (
+                                        <div key={groupKey} className="bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm rounded-2xl shadow-xl border border-slate-200/50 dark:border-slate-700/50 overflow-hidden">
+                                            <div className="px-5 py-3 border-b border-slate-200/70 dark:border-slate-700/70 bg-slate-50/80 dark:bg-slate-700/60">
+                                                <h3 className="font-semibold text-slate-900 dark:text-white">{title}</h3>
+                                            </div>
+                                            <div className="divide-y divide-slate-200/70 dark:divide-slate-700/70">
+                                                {events.map((event) => (
+                                                    <div key={event.id} className="px-5 py-3 flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+                                                        <div>
+                                                            <p className="text-sm font-medium text-slate-900 dark:text-white">
+                                                                {event.benefitName || 'Bulk action'} {actionLabel[event.action] || event.action}
+                                                            </p>
+                                                            <p className="text-xs text-slate-500 dark:text-slate-400">
+                                                                {event.cardName || 'All cards'} · {new Date(event.timestamp).toLocaleString()}
+                                                            </p>
+                                                        </div>
+                                                        <div className="text-xs text-slate-600 dark:text-slate-400">
+                                                            {event.periodKey ? `Period: ${formatPeriodLabel(event.periodKey, event.frequency)}` : 'No period'}
+                                                        </div>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )}
+                    </main>
+                </div>
+            );
+        }
+
         function App() {
             const [cards, setCards] = useState(() => {
                 const saved = localStorage.getItem('creditCardBenefits');
@@ -1631,7 +2056,18 @@
                 return [];
             });
             const [viewMode, setViewMode] = useState('unused'); // 'card', 'list', 'unused'
-            const [currentPage, setCurrentPage] = useState('dashboard'); // 'dashboard', 'add-cards', 'settings'
+            const [currentPage, setCurrentPage] = useState('dashboard'); // 'dashboard', 'add-cards', 'settings', 'history'
+            const [usageHistory, setUsageHistory] = useState(() => {
+                const saved = localStorage.getItem(HISTORY_STORAGE_KEY);
+                if (!saved) return [];
+                try {
+                    const parsed = JSON.parse(saved);
+                    return Array.isArray(parsed) ? parsed : [];
+                } catch (error) {
+                    console.warn('Failed to parse usage history, resetting to empty.', error);
+                    return [];
+                }
+            });
 
             // Add dark mode state
             const [isDarkMode, setIsDarkMode] = useState(() => localStorage.getItem('darkMode') === 'true');
@@ -1659,6 +2095,36 @@
                 localStorage.setItem('creditCardBenefits', JSON.stringify(cards));
             }, [cards]);
 
+            useEffect(() => {
+                localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(usageHistory.slice(0, HISTORY_MAX_ENTRIES)));
+            }, [usageHistory]);
+
+            const appendUsageEvent = ({
+                action,
+                cardId = null,
+                cardName = null,
+                benefitId = null,
+                benefitName = null,
+                frequency = null,
+                amountUsed = null
+            }) => {
+                const timestamp = new Date().toISOString();
+                const periodKey = frequency ? getPeriodKey(frequency, timestamp, { name: benefitName || '' }) : null;
+                const event = {
+                    id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+                    timestamp,
+                    action,
+                    cardId,
+                    cardName,
+                    benefitId,
+                    benefitName,
+                    frequency,
+                    periodKey,
+                    amountUsed
+                };
+                setUsageHistory((prev) => [event, ...prev].slice(0, HISTORY_MAX_ENTRIES));
+            };
+
             const handleToggle = (cardId, benefitId) => {
                 setCards(prevCards => {
                     return prevCards.map(card => {
@@ -1672,6 +2138,14 @@
                                             if (!benefit.subscribed) {
                                                 setUndoableUsed(prev => new Set([...prev, benefitId]));
                                             }
+                                            appendUsageEvent({
+                                                action: benefit.subscribed ? 'unsubscribed' : 'subscribed',
+                                                cardId: card.id,
+                                                cardName: card.name,
+                                                benefitId: benefit.id,
+                                                benefitName: benefit.name,
+                                                frequency: benefit.frequency
+                                            });
                                             if (typeof gtag !== 'undefined') {
                                                 gtag('event', 'subscription_toggle', {
                                                     card_name: card.name,
@@ -1685,6 +2159,15 @@
                                             if (!benefit.used) {
                                                 setRecentlyUsed(prev => new Set([...prev, benefitId]));
                                                 setUndoableUsed(prev => new Set([...prev, benefitId]));
+                                                appendUsageEvent({
+                                                    action: 'used',
+                                                    cardId: card.id,
+                                                    cardName: card.name,
+                                                    benefitId: benefit.id,
+                                                    benefitName: benefit.name,
+                                                    frequency: benefit.frequency,
+                                                    amountUsed: benefit.value
+                                                });
                                             }
                                             if (typeof gtag !== 'undefined') {
                                                 gtag('event', 'benefit_used', {
@@ -1715,8 +2198,24 @@
                                 benefits: card.benefits.map(benefit => {
                                     if (benefit.id === benefitId) {
                                         if (benefit.type === BENEFIT_TYPE.SUBSCRIPTION) {
+                                            appendUsageEvent({
+                                                action: 'unsubscribed',
+                                                cardId: card.id,
+                                                cardName: card.name,
+                                                benefitId: benefit.id,
+                                                benefitName: benefit.name,
+                                                frequency: benefit.frequency
+                                            });
                                             return { ...benefit, subscribed: false };
                                         } else if (benefit.type === BENEFIT_TYPE.CREDIT || benefit.type === BENEFIT_TYPE.ONE_TIME) {
+                                            appendUsageEvent({
+                                                action: 'undo_used',
+                                                cardId: card.id,
+                                                cardName: card.name,
+                                                benefitId: benefit.id,
+                                                benefitName: benefit.name,
+                                                frequency: benefit.frequency
+                                            });
                                             return { ...benefit, used: false };
                                         }
                                     }
@@ -1778,6 +2277,13 @@
 
             // Reset functions
             const handleResetAll = () => {
+                appendUsageEvent({
+                    action: 'reset_all',
+                    cardId: null,
+                    cardName: null,
+                    benefitId: null,
+                    benefitName: null
+                });
                 setCards([]);
                 localStorage.removeItem('creditCardBenefits');
                 
@@ -1788,6 +2294,13 @@
             };
 
             const handleResetBenefitUsage = () => {
+                appendUsageEvent({
+                    action: 'reset_usage',
+                    cardId: null,
+                    cardName: null,
+                    benefitId: null,
+                    benefitName: null
+                });
                 setCards(prevCards => {
                     return prevCards.map(card => ({
                         ...card,
@@ -1851,6 +2364,16 @@
                         onBack={() => setCurrentPage('dashboard')}
                         onResetAll={handleResetAll}
                         onResetBenefitUsage={handleResetBenefitUsage}
+                    />
+                );
+            }
+
+            if (currentPage === 'history') {
+                return (
+                    <UsageHistoryPage
+                        historyEvents={usageHistory}
+                        cards={cards}
+                        onBack={() => setCurrentPage('dashboard')}
                     />
                 );
             }
@@ -1946,6 +2469,24 @@
                                         >
                                             Settings
                                         </button>
+                                        <button
+                                            onClick={() => {
+                                                setCurrentPage('history');
+                                                if (typeof gtag !== 'undefined') {
+                                                    gtag('event', 'page_view', {
+                                                        page_title: 'Usage History',
+                                                        page_location: 'history'
+                                                    });
+                                                }
+                                            }}
+                                            className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg transition-all duration-200 ${
+                                                currentPage === 'history'
+                                                    ? 'bg-white dark:bg-slate-600 text-slate-900 dark:text-white shadow-sm'
+                                                    : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white hover:bg-white/50 dark:hover:bg-slate-600/50'
+                                            }`}
+                                        >
+                                            History
+                                        </button>
                                     </div>
                                 </div>
                             </div>
@@ -2000,6 +2541,17 @@
                                     <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-2">Benefit Lists</h2>
                                     <p className="text-slate-600 dark:text-slate-400">Track and manage all your credit card benefits</p>
                                 </div>
+                                <ContextualFeedbackForm
+                                    contextType="benefits-summary"
+                                    title="Spot a benefit issue?"
+                                    prompt="Report a missing benefit, incorrect amount, or stale details."
+                                    defaultIssueType="missing_benefit"
+                                    pageMeta={`dashboard-${viewMode}`}
+                                    quickActions={[
+                                        { label: 'Report missing benefit', issueType: 'missing_benefit' },
+                                        { label: 'Report wrong benefit', issueType: 'incorrect_benefit' }
+                                    ]}
+                                />
                                 
                                 {getAllBenefits().length === 0 ? (
                                     <div className="bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm rounded-2xl shadow-xl border border-slate-200/50 dark:border-slate-700/50 p-12 text-center">
@@ -2110,9 +2662,20 @@
                                 <p className="text-xs mt-2 text-slate-400">
                                     Data is stored locally in your browser. No information is sent to any server.
                                 </p>
-                                <p className="text-xs mt-2 text-slate-400">
-                                    For support or feature requests, email <a href="mailto:shotadevelops@gmail.com" className="underline">shotadevelops@gmail.com</a>.
-                                </p>
+                                <div className="mt-4 max-w-2xl mx-auto">
+                                    <ContextualFeedbackForm
+                                        contextType="footer-support"
+                                        title="Support and feature requests"
+                                        prompt="Send us bug reports or ideas directly from the app."
+                                        compact={true}
+                                        defaultIssueType="other"
+                                        pageMeta={`footer-${currentPage}-${viewMode}`}
+                                        quickActions={[
+                                            { label: 'Send feedback', issueType: 'other' },
+                                            { label: 'Feature request', issueType: 'feature_request' }
+                                        ]}
+                                    />
+                                </div>
                             </div>
                         </footer>
                     </div>

--- a/js/app.js
+++ b/js/app.js
@@ -6,13 +6,54 @@ function App() {
         }
         return [];
     });
+    const [usageHistory, setUsageHistory] = React.useState(() => {
+        const saved = localStorage.getItem(HISTORY_STORAGE_KEY);
+        if (!saved) return [];
+        try {
+            const parsed = JSON.parse(saved);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch (error) {
+            console.warn('Failed to parse usage history, resetting to empty.', error);
+            return [];
+        }
+    });
     const [viewMode, setViewMode] = React.useState('unused'); // 'card', 'list', 'unused'
     const [showAddModal, setShowAddModal] = React.useState(false);
-    const [currentPage, setCurrentPage] = React.useState('dashboard'); // 'dashboard', 'settings'
+    const [currentPage, setCurrentPage] = React.useState('dashboard'); // 'dashboard', 'settings', 'history'
 
     React.useEffect(() => {
         localStorage.setItem('creditCardBenefits', JSON.stringify(cards));
     }, [cards]);
+
+    React.useEffect(() => {
+        localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(usageHistory.slice(0, HISTORY_MAX_ENTRIES)));
+    }, [usageHistory]);
+
+    const appendUsageEvent = ({
+        action,
+        cardId = null,
+        cardName = null,
+        benefitId = null,
+        benefitName = null,
+        frequency = null,
+        amountUsed = null
+    }) => {
+        const timestamp = new Date().toISOString();
+        const periodKey = frequency ? getPeriodKey(frequency, timestamp, { name: benefitName || '' }) : null;
+        const event = {
+            id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+            timestamp,
+            action,
+            cardId,
+            cardName,
+            benefitId,
+            benefitName,
+            frequency,
+            periodKey,
+            amountUsed
+        };
+        setUsageHistory(prev => [event, ...prev].slice(0, HISTORY_MAX_ENTRIES));
+    };
 
     const handleToggle = (cardId, benefitId) => {
         setCards(prevCards => {
@@ -23,8 +64,27 @@ function App() {
                         benefits: card.benefits.map(benefit => {
                             if (benefit.id === benefitId) {
                                 if (benefit.type === BENEFIT_TYPE.SUBSCRIPTION) {
+                                    appendUsageEvent({
+                                        action: benefit.subscribed ? 'unsubscribed' : 'subscribed',
+                                        cardId: card.id,
+                                        cardName: card.name,
+                                        benefitId: benefit.id,
+                                        benefitName: benefit.name,
+                                        frequency: benefit.frequency
+                                    });
                                     return { ...benefit, subscribed: !benefit.subscribed };
                                 } else if (benefit.type === BENEFIT_TYPE.CREDIT || benefit.type === BENEFIT_TYPE.ONE_TIME) {
+                                    if (!benefit.used) {
+                                        appendUsageEvent({
+                                            action: 'used',
+                                            cardId: card.id,
+                                            cardName: card.name,
+                                            benefitId: benefit.id,
+                                            benefitName: benefit.name,
+                                            frequency: benefit.frequency,
+                                            amountUsed: benefit.value
+                                        });
+                                    }
                                     return { ...benefit, used: true };
                                 }
                             }
@@ -60,11 +120,13 @@ function App() {
 
     // Reset functions
     const handleResetAll = () => {
+        appendUsageEvent({ action: 'reset_all' });
         setCards([]);
         localStorage.removeItem('creditCardBenefits');
     };
 
     const handleResetBenefitUsage = () => {
+        appendUsageEvent({ action: 'reset_usage' });
         setCards(prevCards => {
             return prevCards.map(card => ({
                 ...card,
@@ -113,6 +175,16 @@ function App() {
         );
     }
 
+    if (currentPage === 'history') {
+        return (
+            <UsageHistoryPage
+                historyEvents={usageHistory}
+                cards={cards}
+                onBack={() => setCurrentPage('dashboard')}
+            />
+        );
+    }
+
     // Render dashboard
     return (
         <div className="min-h-screen bg-gray-100">
@@ -126,6 +198,12 @@ function App() {
                                 className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700 transition-colors text-sm font-medium"
                             >
                                 Settings
+                            </button>
+                            <button
+                                onClick={() => setCurrentPage('history')}
+                                className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors text-sm font-medium"
+                            >
+                                History
                             </button>
                             <button
                                 onClick={() => setShowAddModal(true)}

--- a/js/components.js
+++ b/js/components.js
@@ -771,8 +771,8 @@ function SettingsPage({ onBack, onResetAll, onResetBenefitUsage }) {
                         <div className="border border-red-200 rounded-lg p-6 bg-red-50">
                             <h3 className="text-lg font-semibold text-red-900 mb-2">Reset All Data</h3>
                             <p className="text-red-700 mb-4">
-                                <strong>Warning:</strong> This will permanently delete all your data including cards and benefit usage. 
-                                This action cannot be undone.
+                                <strong>Warning:</strong> This will permanently delete all your cards and current benefit usage state.
+                                Usage history records are retained for audit purposes.
                             </p>
                             <button
                                 onClick={() => setShowResetAllModal(true)}
@@ -800,8 +800,8 @@ function SettingsPage({ onBack, onResetAll, onResetBenefitUsage }) {
                     <div className="bg-white rounded-lg p-6 max-w-md w-full">
                         <h3 className="text-lg font-semibold text-gray-900 mb-4">Confirm Reset All Data</h3>
                         <p className="text-gray-600 mb-6">
-                            Are you sure you want to delete all your data? This will remove all cards and benefit usage history. 
-                            This action cannot be undone.
+                            Are you sure you want to delete all your cards and active usage state?
+                            Usage history will be kept.
                         </p>
                         <div className="flex gap-3 justify-end">
                             <button
@@ -847,6 +847,173 @@ function SettingsPage({ onBack, onResetAll, onResetBenefitUsage }) {
                     </div>
                 </div>
             )}
+        </div>
+    );
+}
+
+function UsageHistoryPage({ historyEvents, cards, onBack }) {
+    const [selectedCardId, setSelectedCardId] = React.useState('all');
+    const [selectedAction, setSelectedAction] = React.useState('all');
+    const [groupMode, setGroupMode] = React.useState('date');
+    const [fromDate, setFromDate] = React.useState('');
+    const [toDateFilter, setToDateFilter] = React.useState('');
+
+    const cardOptions = React.useMemo(() => {
+        const options = [{ id: 'all', name: 'All Cards' }];
+        cards.forEach((card) => options.push({ id: card.id, name: card.name }));
+        return options;
+    }, [cards]);
+
+    const filteredEvents = React.useMemo(() => {
+        return historyEvents.filter((event) => {
+            if (selectedCardId !== 'all' && event.cardId !== selectedCardId) return false;
+            if (selectedAction !== 'all' && event.action !== selectedAction) return false;
+
+            const eventDate = toDate(event.timestamp);
+            if (fromDate) {
+                const from = new Date(`${fromDate}T00:00:00`);
+                if (eventDate < from) return false;
+            }
+            if (toDateFilter) {
+                const to = new Date(`${toDateFilter}T23:59:59`);
+                if (eventDate > to) return false;
+            }
+            return true;
+        });
+    }, [historyEvents, selectedCardId, selectedAction, fromDate, toDateFilter]);
+
+    const groupedEvents = React.useMemo(() => {
+        return filteredEvents.reduce((acc, event) => {
+            const date = toDate(event.timestamp);
+            const groupKey = groupMode === 'period'
+                ? `${event.periodKey || 'unknown'}::${event.frequency || 'unknown'}`
+                : date.toISOString().slice(0, 10);
+            if (!acc[groupKey]) {
+                acc[groupKey] = [];
+            }
+            acc[groupKey].push(event);
+            return acc;
+        }, {});
+    }, [filteredEvents, groupMode]);
+
+    const sortedGroupKeys = React.useMemo(() => {
+        return Object.keys(groupedEvents).sort((a, b) => b.localeCompare(a));
+    }, [groupedEvents]);
+
+    const actionLabel = {
+        used: 'Marked used',
+        undo_used: 'Usage undone',
+        subscribed: 'Subscribed',
+        unsubscribed: 'Unsubscribed',
+        reset_usage: 'Reset benefit usage',
+        reset_all: 'Reset all data'
+    };
+
+    return (
+        <div className="min-h-screen bg-gray-100">
+            <header className="bg-white shadow-sm">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+                    <div className="flex items-center gap-4">
+                        <button
+                            onClick={onBack}
+                            className="flex items-center gap-2 text-gray-600 hover:text-gray-900 transition-colors"
+                        >
+                            <span className="text-xl">←</span>
+                            <span>Back to Dashboard</span>
+                        </button>
+                        <h1 className="text-3xl font-bold text-gray-900">Usage History</h1>
+                    </div>
+                </div>
+            </header>
+
+            <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+                <div className="bg-white rounded-lg shadow-lg p-4">
+                    <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+                        <select
+                            value={selectedCardId}
+                            onChange={(e) => setSelectedCardId(e.target.value)}
+                            className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+                        >
+                            {cardOptions.map((card) => (
+                                <option key={card.id} value={card.id}>{card.name}</option>
+                            ))}
+                        </select>
+                        <select
+                            value={selectedAction}
+                            onChange={(e) => setSelectedAction(e.target.value)}
+                            className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+                        >
+                            <option value="all">All Actions</option>
+                            <option value="used">Marked used</option>
+                            <option value="undo_used">Usage undone</option>
+                            <option value="subscribed">Subscribed</option>
+                            <option value="unsubscribed">Unsubscribed</option>
+                            <option value="reset_usage">Reset usage</option>
+                            <option value="reset_all">Reset all</option>
+                        </select>
+                        <input
+                            type="date"
+                            value={fromDate}
+                            onChange={(e) => setFromDate(e.target.value)}
+                            className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+                        />
+                        <input
+                            type="date"
+                            value={toDateFilter}
+                            onChange={(e) => setToDateFilter(e.target.value)}
+                            className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+                        />
+                        <select
+                            value={groupMode}
+                            onChange={(e) => setGroupMode(e.target.value)}
+                            className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+                        >
+                            <option value="date">Group by Date</option>
+                            <option value="period">Group by Period</option>
+                        </select>
+                    </div>
+                </div>
+
+                {filteredEvents.length === 0 ? (
+                    <div className="bg-white rounded-lg shadow-lg p-8 text-center">
+                        <p className="text-gray-600">No usage events yet.</p>
+                    </div>
+                ) : (
+                    <div className="space-y-5">
+                        {sortedGroupKeys.map((groupKey) => {
+                            const events = groupedEvents[groupKey].slice().sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+                            const [periodKey, frequency] = groupKey.split('::');
+                            const title = groupMode === 'period'
+                                ? formatPeriodLabel(periodKey, frequency)
+                                : groupKey;
+                            return (
+                                <div key={groupKey} className="bg-white rounded-lg shadow-lg overflow-hidden">
+                                    <div className="px-5 py-3 border-b border-gray-200 bg-gray-50">
+                                        <h3 className="font-semibold text-gray-900">{title}</h3>
+                                    </div>
+                                    <div className="divide-y divide-gray-200">
+                                        {events.map((event) => (
+                                            <div key={event.id} className="px-5 py-3 flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+                                                <div>
+                                                    <p className="text-sm font-medium text-gray-900">
+                                                        {event.benefitName || 'Bulk action'} {actionLabel[event.action] || event.action}
+                                                    </p>
+                                                    <p className="text-xs text-gray-500">
+                                                        {event.cardName || 'All cards'} · {new Date(event.timestamp).toLocaleString()}
+                                                    </p>
+                                                </div>
+                                                <div className="text-xs text-gray-600">
+                                                    {event.periodKey ? `Period: ${formatPeriodLabel(event.periodKey, event.frequency)}` : 'No period'}
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+            </main>
         </div>
     );
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,39 +1,80 @@
+const HISTORY_STORAGE_KEY = 'benefitUsageHistory';
+const HISTORY_MAX_ENTRIES = 3000;
+
+const toDate = (dateLike = new Date()) => {
+    const parsed = dateLike instanceof Date ? new Date(dateLike) : new Date(dateLike);
+    return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+};
+
+const getSemiAnnualHalfFromBenefit = (benefit = {}) => {
+    const normalized = String(benefit.name || '').replace(/–/g, '-').toLowerCase();
+    if (normalized.includes('jan-jun') || normalized.includes('(h1)')) {
+        return 'H1';
+    }
+    if (normalized.includes('jul-dec') || normalized.includes('(h2)')) {
+        return 'H2';
+    }
+    return null;
+};
+
+const getPeriodKey = (frequency, referenceDate = new Date(), benefit = {}) => {
+    const date = toDate(referenceDate);
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const monthKey = String(month).padStart(2, '0');
+
+    switch (frequency) {
+        case BENEFIT_FREQUENCY.MONTHLY:
+            return `${year}-${monthKey}`;
+        case BENEFIT_FREQUENCY.SEMI_ANNUAL: {
+            const forcedHalf = getSemiAnnualHalfFromBenefit(benefit);
+            const derivedHalf = month <= 6 ? 'H1' : 'H2';
+            return `${year}-${forcedHalf || derivedHalf}`;
+        }
+        case BENEFIT_FREQUENCY.ANNUAL:
+        case BENEFIT_FREQUENCY.ONE_TIME:
+            return `${year}`;
+        case BENEFIT_FREQUENCY.FOUR_YEAR: {
+            const periodStart = year - (year % 4);
+            return `${periodStart}-${periodStart + 3}`;
+        }
+        default:
+            return `${year}`;
+    }
+};
+
+const formatPeriodLabel = (periodKey, frequency) => {
+    if (!periodKey) return 'Unknown period';
+    if (frequency === BENEFIT_FREQUENCY.SEMI_ANNUAL) {
+        return periodKey.replace('-', ' ');
+    }
+    return periodKey;
+};
+
 // Helper function to get current benefit amount based on date
-const getCurrentBenefitAmount = (benefit, frequency) => {
-    const now = new Date();
-    const currentMonth = now.getMonth();
-    const currentYear = now.getFullYear();
+const getCurrentBenefitAmount = (benefit, frequency, referenceDate = new Date()) => {
+    const date = toDate(referenceDate);
+    const currentMonth = date.getMonth();
     
     switch (frequency) {
-        case BENEFIT_FREQUENCY.SEMI_ANNUAL:
-            // For semi-annual benefits, return half the value
-            if (benefit.name.includes('Jan-Jun') && currentMonth >= 6) {
-                return 0; // This period has passed
-            }
-            if (benefit.name.includes('Jul-Dec') && currentMonth < 6) {
-                return 0; // This period hasn't started
+        case BENEFIT_FREQUENCY.SEMI_ANNUAL: {
+            const benefitHalf = getSemiAnnualHalfFromBenefit(benefit);
+            const currentHalf = currentMonth < 6 ? 'H1' : 'H2';
+            if (benefitHalf && benefitHalf !== currentHalf) {
+                return 0;
             }
             return benefit.value;
-        case BENEFIT_FREQUENCY.ANNUAL:
-            // For annual benefits that accumulate monthly
-            if (benefit.name === '$300 StubHub/Viagogo Credit') {
-                // $25 per month
-                return Math.min(25 * (currentMonth + 1), 300);
-            }
-            return benefit.value;
-        case BENEFIT_FREQUENCY.FOUR_YEAR:
-            // TSA PreCheck is $120 every 4 years, not annual
-            return benefit.value;
+        }
         default:
             return benefit.value;
     }
 };
 
 // Helper functions
-const getExpirationDate = (frequency) => {
-    const now = new Date();
-    const currentYear = now.getFullYear();
-    const currentMonth = now.getMonth();
+const getExpirationDate = (frequency, referenceDate = new Date()) => {
+    const date = toDate(referenceDate);
+    const currentYear = date.getFullYear();
+    const currentMonth = date.getMonth();
     
     switch (frequency) {
         case BENEFIT_FREQUENCY.MONTHLY:
@@ -45,9 +86,13 @@ const getExpirationDate = (frequency) => {
                 return new Date(currentYear, 11, 31);
             }
         case BENEFIT_FREQUENCY.ANNUAL:
+        case BENEFIT_FREQUENCY.ONE_TIME:
             return new Date(currentYear, 11, 31);
-        case BENEFIT_FREQUENCY.FOUR_YEAR:
-            return new Date(currentYear + 4, 11, 31);
+        case BENEFIT_FREQUENCY.FOUR_YEAR: {
+            const periodKey = getPeriodKey(BENEFIT_FREQUENCY.FOUR_YEAR, date);
+            const endYear = Number(periodKey.split('-')[1]);
+            return new Date(endYear, 11, 31);
+        }
         default:
             return new Date(currentYear, 11, 31);
     }

--- a/test-suite.html
+++ b/test-suite.html
@@ -260,6 +260,41 @@
             );
         }
 
+        function simulateGetPeriodKey(frequency, referenceDate) {
+            const date = new Date(referenceDate);
+            const year = date.getFullYear();
+            const month = date.getMonth() + 1;
+            const monthKey = String(month).padStart(2, '0');
+
+            switch (frequency) {
+                case BENEFIT_FREQUENCY.MONTHLY:
+                    return `${year}-${monthKey}`;
+                case BENEFIT_FREQUENCY.SEMI_ANNUAL:
+                    return `${year}-${month <= 6 ? 'H1' : 'H2'}`;
+                case BENEFIT_FREQUENCY.ANNUAL:
+                case BENEFIT_FREQUENCY.ONE_TIME:
+                    return `${year}`;
+                case BENEFIT_FREQUENCY.FOUR_YEAR: {
+                    const start = year - (year % 4);
+                    return `${start}-${start + 3}`;
+                }
+                default:
+                    return `${year}`;
+            }
+        }
+
+        function simulateAppendUsageEvent(history, payload) {
+            const timestamp = payload.timestamp || new Date().toISOString();
+            return [{
+                id: `test-${history.length + 1}`,
+                timestamp,
+                action: payload.action,
+                cardId: payload.cardId || null,
+                benefitId: payload.benefitId || null,
+                periodKey: payload.frequency ? simulateGetPeriodKey(payload.frequency, timestamp) : null
+            }, ...history];
+        }
+
         // Test cases
         function testHandleToggleCreditBenefit() {
             logTestInfo('Testing handleToggle for credit benefit...');
@@ -397,6 +432,39 @@
             );
         }
 
+        function testPeriodKeyGeneration() {
+            logTestInfo('Testing period key generation...');
+
+            const monthly = simulateGetPeriodKey(BENEFIT_FREQUENCY.MONTHLY, '2026-03-15T00:00:00Z');
+            const semiAnnualH2 = simulateGetPeriodKey(BENEFIT_FREQUENCY.SEMI_ANNUAL, '2026-07-01T00:00:00Z');
+            const annual = simulateGetPeriodKey(BENEFIT_FREQUENCY.ANNUAL, '2026-11-20T00:00:00Z');
+
+            logTestResult(
+                'Period Key Generation',
+                monthly === '2026-03' && semiAnnualH2 === '2026-H2' && annual === '2026',
+                `Monthly=${monthly}, SemiAnnual=${semiAnnualH2}, Annual=${annual}`
+            );
+        }
+
+        function testUsageHistoryAppend() {
+            logTestInfo('Testing usage history append behavior...');
+
+            const initialHistory = [];
+            const nextHistory = simulateAppendUsageEvent(initialHistory, {
+                action: 'used',
+                cardId: 'test-card',
+                benefitId: 'test-credit-benefit',
+                frequency: BENEFIT_FREQUENCY.MONTHLY,
+                timestamp: '2026-03-12T10:15:00Z'
+            });
+
+            logTestResult(
+                'Usage History Append',
+                nextHistory.length === 1 && nextHistory[0].periodKey === '2026-03' && nextHistory[0].action === 'used',
+                `Stored action=${nextHistory[0].action}, period=${nextHistory[0].periodKey}`
+            );
+        }
+
         // Main test runner
         function runAllTests() {
             clearResults();
@@ -409,6 +477,8 @@
             testBenefitIdGeneration();
             testCurrencyFormatting();
             testExpirationDateCalculation();
+            testPeriodKeyGeneration();
+            testUsageHistoryAppend();
             
             logTestInfo('All automated tests completed.');
             displayResults();


### PR DESCRIPTION
## Summary

- **Usage history audit log** – New `UsageHistoryPage` with filters (card, action type, from/to date) and grouping by date or benefit period. Every mark-used/undo/subscribe/unsubscribe and each reset action now appends a timestamped event to `localStorage` (`benefitUsageHistory`, capped at 3000 entries). History is preserved through "Reset All" / "Reset Usage" so users keep an audit trail.
- **Contextual feedback form** – Added a reusable `ContextualFeedbackForm` (Formspree-backed) wired into the Add Cards page, Benefits Summary, and footer so users can report missing cards, incorrect benefits, or feature requests without leaving the app. Includes quick-action buttons and graceful fallback to an email address if the endpoint is not configured.
- **Frequency helper refactor** – Introduced `getPeriodKey`, `formatPeriodLabel`, `toDate`, and `getSemiAnnualHalfFromBenefit`. `getCurrentBenefitAmount` and `getExpirationDate` now handle semi-annual (H1/H2), annual, one-time, and four-year frequencies more consistently and accept an optional reference date for testability.
- **Settings copy + tests** – Clarified reset copy to mention usage history retention, and added `test-suite.html` cases for period key generation and usage history append.

Note: this branch also includes two previously-unpushed local commits (`sticky column`, `Agent.md`) that landed in `master` locally but had not yet been pushed to `origin/master`.

## Test plan

- [ ] Load the app, mark benefits used/unused, subscribe/unsubscribe, and verify events appear in the new History page with correct card, action, period, and timestamp.
- [ ] Apply History filters (card, action, date range) and switch between "Group by Date" and "Group by Period" – confirm results update correctly.
- [ ] Trigger Settings → Reset Benefit Usage and Reset All; confirm usage history is retained and a reset event is appended.
- [ ] Submit the contextual feedback form from Add Cards, Benefits Summary, and footer, and confirm the Formspree request succeeds (or shows the fallback error when the endpoint is unset).
- [ ] Open `test-suite.html` and run all tests; verify the new Period Key Generation and Usage History Append tests pass along with existing ones.
- [ ] Sanity-check semi-annual (Jan–Jun / Jul–Dec), annual, one-time, and four-year benefits still show the correct current amount and expiration.

Made with [Cursor](https://cursor.com)